### PR TITLE
Closes #5 - Add build and release scripts

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,0 +1,63 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - '**'
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: robokitty
+          path: dist/
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: robokitty
+          path: dist/
+      - name: Extract release notes
+        id: extract-release-notes
+        uses: ffurrer2/extract-release-notes@v3
+      - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ github.ref_name }} \
+          dist/*.whl \
+          dist/*.tar.gz \
+          --notes '${{ steps.extract-release-notes.outputs.release_notes }}' \
+          --title ${{ github.ref_name }} \
+          --verify-tag

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,9 +1,9 @@
 name: pre-commit
 
 on:
-  pull_request:
   push:
-    branches: [dev]
+    branches:
+      - '**'
 
 jobs:
   pre-commit:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,77 +1,58 @@
 # Changelog
-
 All notable changes to this project are documented in this file.
 
 Versions prior to 2.3 were developed outside of version control and are not included in the Git history. They are documented here to provide context and highlight key project milestones.
 
----
-## [2.4] - Latest
+## [Unreleased]
+### Added
+* Build pipeline to generate Python wheel packages
+* Release pipeline to publish changelog on tag/release
 
-### Improvements
+### Changed
+* Modify pre-commit to execute on every push
 
-* Add stream and file based logger
+## [v2.4.0]
+### Added
+* Stream and file based logger
+* CI actions for code quality checks
+
+### Changed
 * Reorganised code base to fit basic python project
-* Added CI actions for code quality checks
 
----
-
-## [2.3]
-
-### Major Changes
-
+## [v2.3.0]
+### Changed
 * Increased step length from 40 mm to 80 mm
-
 * Reduced cycle time from 2.4 s to 1.6 s
-
 * Each 20 ms control cycle now moves the femur by 3.6 servo units (previously 0.5 units, below AX-12A compliance threshold and resulting in no torque)
-
 * Set compliance margin to 0 on all servos, removing the 1-unit dead zone where no force is applied
-
 * Increased step height from 18 mm to 25 mm to improve ground clearance
 
-### Fixes
-
+### Fixed
 * Corrected movement direction (introduced in version 2.2), ensuring stance phase pushes toward the physical front (-x axis)
 
----
+## [v2.0.0]
+### Added
+* Ground press behaviour
 
-## [2.0]
-
-### Changes
-
-* Added ground press behaviour
+### Changed
 * Removed simulation mode
 
----
-
-## [1.9]
-
-### Features
-
+## [v1.9.0]
+### Added
 * Implemented walk (creep) gait
-* Added body centre-of-mass shifting
+* Body centre-of-mass shifting
 
----
+## [v1.8.0]
+### Added
+* Audit logging
 
-## [1.8]
-
-### Improvements
-
+### Changed
 * Increased gait swing amplitude
-* Added audit logging
 
----
-
-## [1.7]
-
-### Changes
-
+## [v1.7.0]
+### Changed
 * Applied calibrated servo offsets
 
----
-
-## [1.0]
-
-### Initial Release
-
+## [v1.0.0]
+### Added
 * Initial system implementation


### PR DESCRIPTION
- Add build pipeline to generate Python wheel packages
- Add release pipeline to publish changelog on tag/release
- Modify pre-commit to execute on every push

See Also: #5 